### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get install -y \
     python-dev \
     python-pip \
     python-soappy \
-    python-pbr \
     python-dateutil \
     openssh-client \
     sshpass \
@@ -21,7 +20,7 @@ RUN apt-get update && apt-get install -y \
  && rm -rf /var/lib/apt/lists/*
 
 # Install CherryPy to enable HTTPS in REST API
-RUN pip install CherryPy pyOpenSSL
+RUN pip install pbr CherryPy pyOpenSSL
 
 # Install tosca-parser
 RUN cd tmp \


### PR DESCRIPTION
The python-pbr library is not updated to the version needed.
So, the pbr library needs to be installed from pip.