### PR TITLE
Errata in Dockerfile prevented from Building Docker Image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     libffi-dev \
     libmysqld-dev \
-    python-pysqlite2
+    python-pysqlite2 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The offending line was:
python-pysqlite2 
which should read:
python-pysqlite2 \